### PR TITLE
feat: add annotation processor for plugin.yml generation

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -3,6 +3,8 @@
   <component name="Encoding">
     <file url="file://$USER_HOME$/Desktop/src/main/java" charset="UTF-8" />
     <file url="file://$USER_HOME$/Desktop/src/main/resources" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/annotation-processor/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/annotation-processor/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/core/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/core/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/data/src/main/java" charset="UTF-8" />

--- a/annotation-processor/pom.xml
+++ b/annotation-processor/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>me.approximations.spigot-boot</groupId>
+        <artifactId>spigot-boot</artifactId>
+        <version>2.0.0</version>
+    </parent>
+
+    <artifactId>spigot-boot-annotation-processor</artifactId>
+    <version>2.0.0</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <proc>none</proc>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/annotation-processor/src/main/java/me/approximations/spigotBoot/annotationProcessor/annotations/Plugin.java
+++ b/annotation-processor/src/main/java/me/approximations/spigotBoot/annotationProcessor/annotations/Plugin.java
@@ -1,0 +1,39 @@
+package me.approximations.spigotBoot.annotationProcessor.annotations;
+
+import me.approximations.spigotBoot.annotationProcessor.plugin.PluginLoadOrder;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+public @interface Plugin {
+    String name();
+
+    String version();
+
+    String description() default "";
+
+    PluginLoadOrder load() default PluginLoadOrder.POSTWORLD;
+
+    String author() default "";
+
+    String[] authors() default {};
+
+    String website() default "";
+
+    String[] depend() default {};
+
+    String[] softdepend() default {};
+
+    String[] loadbefore() default {};
+
+    String prefix() default "";
+
+    String[] libraries() default {};
+
+    String apiVersion() default "";
+}
+

--- a/annotation-processor/src/main/java/me/approximations/spigotBoot/annotationProcessor/plugin/PluginAnnotationProcessor.java
+++ b/annotation-processor/src/main/java/me/approximations/spigotBoot/annotationProcessor/plugin/PluginAnnotationProcessor.java
@@ -1,0 +1,88 @@
+package me.approximations.spigotBoot.annotationProcessor.plugin;
+
+import me.approximations.spigotBoot.annotationProcessor.annotations.Plugin;
+
+import javax.annotation.processing.*;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@SupportedAnnotationTypes("me.approximations.spigotBoot.annotationProcessor.plugin.annotations.Plugin")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
+public class PluginAnnotationProcessor extends AbstractProcessor {
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        for (TypeElement annotation : annotations) {
+            for (Element element : roundEnv.getElementsAnnotatedWith(annotation)) {
+                Plugin pluginAnnotation = element.getAnnotation(Plugin.class);
+
+                if (pluginAnnotation == null) {
+                    continue;
+                }
+
+                try {
+                    generatePluginYml(pluginAnnotation, element);
+                } catch (IOException e) {
+                    processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "Could not generate plugin.yml: " + e.getMessage(), element);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void generatePluginYml(Plugin pluginAnnotation, Element element) throws IOException {
+        Filer filer = processingEnv.getFiler();
+        FileObject fileObject = filer.createResource(StandardLocation.CLASS_OUTPUT, "", "plugin.yml", element);
+
+        try (PrintWriter writer = new PrintWriter(fileObject.openWriter())) {
+            writer.println("name: " + pluginAnnotation.name());
+            writer.println("version: " + pluginAnnotation.version());
+            writer.println("main: " + ((TypeElement) element).getQualifiedName().toString()); // Assumes the annotated class is the main class
+
+            if (!pluginAnnotation.description().isEmpty()) {
+                writer.println("description: " + pluginAnnotation.description());
+            }
+            if (pluginAnnotation.load() != PluginLoadOrder.POSTWORLD) {
+                writer.println("load: " + pluginAnnotation.load().name());
+            }
+            if (!pluginAnnotation.author().isEmpty()) {
+                writer.println("author: " + pluginAnnotation.author());
+            }
+            if (pluginAnnotation.authors().length > 0) {
+                writer.println("authors: [" + String.join(", ", pluginAnnotation.authors()) + "]");
+            }
+            if (!pluginAnnotation.website().isEmpty()) {
+                writer.println("website: " + pluginAnnotation.website());
+            }
+            if (pluginAnnotation.depend().length > 0) {
+                writer.println("depend: [" + String.join(", ", pluginAnnotation.depend()) + "]");
+            }
+            if (pluginAnnotation.softdepend().length > 0) {
+                writer.println("softdepend: [" + String.join(", ", pluginAnnotation.softdepend()) + "]");
+            }
+            if (pluginAnnotation.loadbefore().length > 0) {
+                writer.println("loadbefore: [" + String.join(", ", pluginAnnotation.loadbefore()) + "]");
+            }
+            if (!pluginAnnotation.prefix().isEmpty()) {
+                writer.println("prefix: " + pluginAnnotation.prefix());
+            }
+            if (pluginAnnotation.libraries().length > 0) {
+                writer.println("libraries: [" + Arrays.stream(pluginAnnotation.libraries()).map(lib -> "'" + lib + "'").collect(Collectors.joining(", ")) + "]");
+            }
+            if (!pluginAnnotation.apiVersion().isEmpty()) {
+                writer.println("api-version: " + pluginAnnotation.apiVersion());
+            }
+        }
+    }
+}
+

--- a/annotation-processor/src/main/java/me/approximations/spigotBoot/annotationProcessor/plugin/PluginLoadOrder.java
+++ b/annotation-processor/src/main/java/me/approximations/spigotBoot/annotationProcessor/plugin/PluginLoadOrder.java
@@ -1,0 +1,7 @@
+package me.approximations.spigotBoot.annotationProcessor.plugin;
+
+public enum PluginLoadOrder {
+    STARTUP,
+    POSTWORLD
+}
+

--- a/annotation-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
+++ b/annotation-processor/src/main/resources/META-INF/services/javax.annotation.processing.Processor
@@ -1,0 +1,1 @@
+me.approximations.spigotBoot.annotationProcessor.plugin.PluginAnnotationProcessor

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -161,6 +161,12 @@
             <version>2.0.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>me.approximations.spigot-boot</groupId>
+            <artifactId>spigot-boot-annotation-processor</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <module>modules</module>
         <module>utils</module>
         <module>tests</module>
+        <module>annotation-processor</module>
     </modules>
 
     <properties>

--- a/tests/test-plugin/src/main/java/me/approximations/apxPlugin/testPlugin/Main.java
+++ b/tests/test-plugin/src/main/java/me/approximations/apxPlugin/testPlugin/Main.java
@@ -3,7 +3,14 @@ package me.approximations.apxPlugin.testPlugin;
 import com.j256.ormlite.support.ConnectionSource;
 import me.approximations.apxPlugin.core.ApxPlugin;
 import me.approximations.apxPlugin.core.di.Inject;
+import me.approximations.spigotBoot.annotationProcessor.annotations.Plugin;
 
+@Plugin(
+        name = "TestPlugin",
+        version = "1.0.0",
+        description = "A test plugin for ApxPlugin framework.",
+        authors = {"Approximations"}
+)
 public class Main extends ApxPlugin {
     @Inject
     private ConnectionSource connectionSource;

--- a/tests/test-plugin/src/main/resources/plugin.yml
+++ b/tests/test-plugin/src/main/resources/plugin.yml
@@ -1,4 +1,0 @@
-name: ApxPluginTest
-author: Approximations
-main: me.approximations.apxPlugin.testPlugin.Main
-version: 1.0


### PR DESCRIPTION
This pull request introduces an annotation processor for generating `plugin.yml` file based on @Plugin annotation. The annotation processor simplifies plugin metadata management by using a custom `@Plugin` annotation. Key changes include the creation of the annotation processor module, updates to project configuration files, and integration of the processor in a test plugin.